### PR TITLE
Remove or modify non-North-American characters in mobile iPad layouts

### DIFF
--- a/crk.kbdgen/layouts/crk.yaml
+++ b/crk.kbdgen/layouts/crk.yaml
@@ -37,7 +37,7 @@ modes:
     shift: |
       Q             W E R T Y U I O P \s{backspace}
       \s{"ˆ":0.5} A S D F G H J K L   \s{return:1.75}
-      \s{shift}   Z X C V B N M , .   \s{shift:1.25}
+      \s{shift}   Z X C V B N M ; :   \s{shift:1.25}
     alt: |
       1             2 3 4 5 6 7 8 9 0 \s{backspace}
       \s{"ˆ":0.5} @ # $ & * ( ) ' "   \s{return:1.75}
@@ -58,27 +58,27 @@ modes:
     default: |
       ' 1 2 3 4 5 6 7 8 9 0 + ´ \s{backspace:1.5}
       \s{spacer:1.5} q w e r t y u i o p
-      \s{caps:1.75} a s d f g h j k l ø æ \s{return:1.75}
-      \s{shift:1.25} ž z č c v b n m , . - \s{shift:2.25}
+      \s{caps:1.75}  a s d f g h j k l \s{return:1.75}
+      \s{shift:1.25} z x c v b n m , . - \s{shift:2.25}
     shift: |
-      § ! " # kr % & / ( ) = ? ` \s{backspace:1.5}
+      § ! " # $ % & / ( ) = ? ` \s{backspace:1.5}
       \s{spacer:1.5} Q W E R T Y U I O P
-      \s{caps:1.75} A S D F G H J K L Ø Æ \s{return:1.75}
-      \s{shift:1.25} Ž Z Č C V B N M ; : _ \s{shift:2.25}
+      \s{caps:1.75}  A S D F G H J K L \s{return:1.75}
+      \s{shift:1.25} Z X C V B N M ; : _ \s{shift:2.25}
     alt: |
-      § ! " # kr % & / ( ) = ? ` \s{backspace:1.5}
+      § ! " # € % & \ [ ] = ? ` \s{backspace:1.5}
       \s{spacer:1.5} q w e r t y u i o p
-      \s{caps:1.75} a s d f g h j k l ö ä \s{return:1.75}
+      \s{caps:1.75}  a s d f g h j k l \s{return:1.75}
       \s{shift:1.25} < z x c v b n m ; : _ \s{shift:2.25}
     alt+shift: |
-      § ! " # kr % & / ( ) = ? ` \s{backspace:1.5}
+      § ! " # £ % & | { } = ? ` \s{backspace:1.5}
       \s{spacer:1.5} Q W E R T Y U I O P
-      \s{caps:1.75} A S D F G H J K L Ö Ä \s{return:1.75}
+      \s{caps:1.75}  A S D F G H J K L \s{return:1.75}
       \s{shift:1.25} > Z X C V B N M ; : _ \s{shift:2.25}
     symbols-1: |
       ` 1 2 3 4 5 6 7 8 9 0 < > \s{backspace:1.5}
       \s{spacer:1.5} [ ] { } # % ^ * + = \ | ~
-      \s{spacer:1.75} - / : ; ( ) kr & @ $ £ \s{return:1.75}
+      \s{spacer:1.75} - / : ; ( ) € & @ $ £ \s{return:1.75}
       \s{spacer:3.25} … . , ? ! ' " _ € \s{spacer:2.25}
   mac:
     default: |

--- a/crk.kbdgen/layouts/crk.yaml
+++ b/crk.kbdgen/layouts/crk.yaml
@@ -64,7 +64,7 @@ modes:
       § ! " # $ % & / ( ) = ? ` \s{backspace:1.5}
       \s{spacer:1.5} Q W E R T Y U I O P
       \s{caps:1.75}  A S D F G H J K L \s{return:1.75}
-      \s{shift:1.25} Z X C V B N M ; : _ \s{shift:2.25}
+      \s{shift:1.25} Z X C V B N M , . _ \s{shift:2.25}
     alt: |
       § ! " # € % & \ [ ] = ? ` \s{backspace:1.5}
       \s{spacer:1.5} q w e r t y u i o p
@@ -79,7 +79,7 @@ modes:
       ` 1 2 3 4 5 6 7 8 9 0 < > \s{backspace:1.5}
       \s{spacer:1.5} [ ] { } # % ^ * + = \ | ~
       \s{spacer:1.75} - / : ; ( ) € & @ $ £ \s{return:1.75}
-      \s{spacer:3.25} … . , ? ! ' " _ € \s{spacer:2.25}
+      \s{spacer:3.25} … . , ? ! ' " _ § \s{spacer:2.25}
   mac:
     default: |
       ` 1 2 3 4 5 6 7 8 9 0 - =


### PR DESCRIPTION
Removed Scandinavian / Saami characters from the layout for 12" iPad.